### PR TITLE
:bug: fix: fix oasis-align-images duplicate image rendering and incorrect width

### DIFF
--- a/oasis-align.typ
+++ b/oasis-align.typ
@@ -298,17 +298,6 @@
 
 
     // Display images in grid
-    display-output(calcWidth1,calcWidth1, vertical, swap)
-    if vertical {
-      grid(rows: (calcWidth1, calcWidth2),
-        image1,
-        image2
-      ) 
-    } else {
-      grid(columns: (calcWidth1, calcWidth2),
-        image1,
-        image2
-      ) 
-    }
+    display-output(calcWidth1, calcWidth2, vertical, swap)
   })
 }


### PR DESCRIPTION
The `oasis-align-images` function is rendering images twice because of the `display-output()` call being followed with the rendering of additional grids. Visually it only seems to show with parameter `vertical=false` though.

It also seems like the second width passed as an argument to `display-output` is wrong (`calcWidth1` instead of `calcWidth2`).

Before:
<img width="894" height="832" alt="image" src="https://github.com/user-attachments/assets/156c7736-803e-4f05-8306-216216c77d9f" />

After: 
<img width="861" height="459" alt="image" src="https://github.com/user-attachments/assets/28c3cb75-6a75-4e5b-9af1-a2e5d72fb7d2" />
