### PR TITLE
Add support for any length for grid.column-gutter

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,9 +132,6 @@ $$w_1' = \left(\frac{h_1 w_2}{w_1 h_2} + 1 \right)^{-1} \qquad w_2' = \left(\fra
 "Oasis" as in a fertile spot in a desert, where water is found. -->
 
 ## Future Work
-### Allow for Relative `grid.column-gutter` sizes
-Presently, I am unable to make the `grid.column-gutter` absolute using the `.to-absolute()` method. Including a relative length in `#set grid(column-gutter)` will throw an error. 
-
 ### Skipping Close Approximations
 Under certain conditions, the function may skip over near-solutions. This is a consequence of using bisection method for root finding, which is not ideal for discontinuous systems and optimized solutions. 
 

--- a/demo/demo.typ
+++ b/demo/demo.typ
@@ -4,7 +4,8 @@
 
 #set page(width: 6in, height: auto, margin: 1in)
 #set par(justify: true)
-#set grid(column-gutter: .2in)
+// #set grid(column-gutter: .2in)
+#set grid(column-gutter: 4%)
 
 #let words = [This is me writing about my cat. I love my cat. He is the best of cats. I give him head scratches until he gets mad at me. He then he starts swatting at my hand. This goes on until my hand gets scratched.]
 

--- a/oasis-align.typ
+++ b/oasis-align.typ
@@ -61,6 +61,9 @@
     //   max: if vertical {measured-container.height - gutter}
     //                else {measured-container.width - container.gutter},
     // )
+    // Relevant container side, depending on `vertical`.
+    let side = if vertical {"height"} else {"width"}
+    let container-side = measured-container.at(side)
     let gutter = if vertical {
       if grid.row-gutter == () {0pt} // In case grid.gutter is not defined
       else {grid.row-gutter.at(0)}
@@ -69,13 +72,8 @@
       else {grid.column-gutter.at(0)}
     }
     // Convert `relative` length to absolute `length`.
-    let gutter = gutter.length.to-absolute() + gutter.ratio * if vertical {
-      measured-container.height
-    } else {
-      measured-container.width
-    }
-    let max-dim = if vertical {measured-container.height - gutter}
-                   else {measured-container.width - gutter}
+    let gutter = container-side * gutter.ratio + gutter.length.to-absolute()
+    let max-dim = container-side - gutter
     // let thing1 = (
     //   dim-a: length, 
     //   dim-b: length,

--- a/oasis-align.typ
+++ b/oasis-align.typ
@@ -50,17 +50,7 @@
   
   // use layout to measure measured-container
   layout(measured-container => {
-    // let container = (
-    //   gutter: if vertical {
-    //     if grid.row-gutter == () {0pt} // In case grid.gutter is not defined
-    //     else {grid.row-gutter.at(0)}
-    //   } else {
-    //     if grid.column-gutter == () {0pt} // In case grid.gutter is not defined
-    //     else {grid.column-gutter.at(0)}
-    //   },
-    //   max: if vertical {measured-container.height - gutter}
-    //                else {measured-container.width - container.gutter},
-    // )
+
     // Relevant container side, depending on `vertical`.
     let side = if vertical {"height"} else {"width"}
     let container-side = measured-container.at(side)
@@ -74,17 +64,13 @@
       gutter = container-side * gutter.ratio + gutter.length.to-absolute()
       gutter
     }
+
     let max-dim = container-side - gutter
-    // let thing1 = (
-    //   dim-a: length, 
-    //   dim-b: length,
-    // )
     let dim-1a    // Bounding dimension of item1
     let dim-2a    // Bounding dimension of item2
     let dim-1b   // Measured dimension of item1 using dim-1a
     let dim-2b   // Measured dimension of item2 using dim-2a
     let start-frac = if int-frac == none {(range.last() + range.first())/2} else {int-frac}
-    // let start-frac = .5
     let frac = start-frac
     let previous-frac 
     let frac-diff = start-frac
@@ -117,7 +103,6 @@
       let diff = calc.abs(out1 - out2)
 
       return (out1, out2, diff)
-
     }
 
     let display-output(dim1, dim2, vertical, swap) = {
@@ -145,9 +130,23 @@
         line-angle = 90deg
       }
 
-      let major-line  = line(length: ruler-dim * ratio, angle: line-angle, stroke: (thickness: .4em, paint: color, cap: "round"))
-      let median-line = line(length: ruler-dim * ratio * .8, angle: line-angle, stroke: (thickness: .3em, paint: color, cap: "round"))
-      let minor-line  = line(length: ruler-dim * ratio * .5 , angle: line-angle, stroke: (thickness: .3em, paint: color, cap: "round"))
+      let major-line  = line(
+        length: ruler-dim * ratio, 
+        angle: line-angle, 
+        stroke: (thickness: .4em, paint: color, cap: "round")
+      )
+
+      let median-line = line(
+        length: ruler-dim * ratio * .8, 
+        angle: line-angle, 
+        stroke: (thickness: .3em, paint: color, cap: "round")
+      )
+
+      let minor-line  = line(
+        length: ruler-dim * ratio * .5, 
+        angle: line-angle, 
+        stroke: (thickness: .3em, paint: color, cap: "round")
+      )
       
       place(
         horizon + center, 
@@ -300,6 +299,7 @@
       gutter = container-side * gutter.ratio + gutter.length.to-absolute()
       gutter
     }
+    
     let max-dim = container-side - gutter
     // Set widths of images
     let calcWidth1 = (max-dim)/(1/ratio + 1)

--- a/oasis-align.typ
+++ b/oasis-align.typ
@@ -288,15 +288,19 @@
   layout(measured-container => {
     // Measure size of continaner
     // let container = size.width
-    let gutter = if vertical {
-      if grid.row-gutter == () {0pt} // In case grid.gutter is not defined
-      else {grid.row-gutter.at(0)}
-    } else {
-      if grid.column-gutter == () {0pt} // In case grid.gutter is not defined
-      else {grid.column-gutter.at(0)}
+    let side = if vertical {"height"} else {"width"}
+    let container-side = measured-container.at(side)
+    let grid-gutter = if vertical {grid.row-gutter} else {grid.column-gutter}
+    let gutter = {
+      // In case grid.gutter is not defined, otherwise get first track sizing.
+      let gutter = if grid-gutter == () {0% + 0pt} else {grid-gutter.first()}
+      // In case grid.gutter is `int`, `auto`, `fraction`, ignore the value.
+      if gutter == auto or type(gutter) == fraction { gutter = 0% + 0pt }
+      // Convert `relative` length to absolute `length`.
+      gutter = container-side * gutter.ratio + gutter.length.to-absolute()
+      gutter
     }
-    let max-dim = if vertical {measured-container.height - gutter}
-                   else {measured-container.width - gutter}
+    let max-dim = container-side - gutter
     // Set widths of images
     let calcWidth1 = (max-dim)/(1/ratio + 1)
     let calcWidth2 = (max-dim)/(ratio + 1)

--- a/oasis-align.typ
+++ b/oasis-align.typ
@@ -68,6 +68,12 @@
       if grid.column-gutter == () {0pt} // In case grid.gutter is not defined
       else {grid.column-gutter.at(0)}
     }
+    // Convert `relative` length to absolute `length`.
+    let gutter = gutter.length.to-absolute() + gutter.ratio * if vertical {
+      measured-container.height
+    } else {
+      measured-container.width
+    }
     let max-dim = if vertical {measured-container.height - gutter}
                    else {measured-container.width - gutter}
     // let thing1 = (

--- a/oasis-align.typ
+++ b/oasis-align.typ
@@ -64,15 +64,16 @@
     // Relevant container side, depending on `vertical`.
     let side = if vertical {"height"} else {"width"}
     let container-side = measured-container.at(side)
-    let gutter = if vertical {
-      if grid.row-gutter == () {0pt} // In case grid.gutter is not defined
-      else {grid.row-gutter.at(0)}
-    } else {
-      if grid.column-gutter == () {0pt} // In case grid.gutter is not defined
-      else {grid.column-gutter.at(0)}
+    let grid-gutter = if vertical {grid.row-gutter} else {grid.column-gutter}
+    let gutter = {
+      // In case grid.gutter is not defined, otherwise get first track sizing.
+      let gutter = if grid-gutter == () {0% + 0pt} else {grid-gutter.first()}
+      // In case grid.gutter is `int`, `auto`, `fraction`, ignore the value.
+      if gutter == auto or type(gutter) == fraction { gutter = 0% + 0pt }
+      // Convert `relative` length to absolute `length`.
+      gutter = container-side * gutter.ratio + gutter.length.to-absolute()
+      gutter
     }
-    // Convert `relative` length to absolute `length`.
-    let gutter = container-side * gutter.ratio + gutter.length.to-absolute()
     let max-dim = container-side - gutter
     // let thing1 = (
     //   dim-a: length, 


### PR DESCRIPTION
Closes #22.

From [grid docs](https://typst.app/docs/reference/layout/grid/#:~:text=A%20fixed%20or%20relative%20length%20%28e%2Eg%2E%2010pt%20or%2020%25%20%2D%201cm%29%3A), it is clear that gutter sizing can also be a `relative` length. Though when receiving, it's always `relative`, apparently. With the given code, it's obvious what to use for the ratio part to convert everything to a comparable on line 209 value.
