### PR TITLE
v0.4.0 changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+## 0.4.0 - 2026/08/04
+- added `padding` to all functions
+    - helps when you don't want the content spanning the full page
+- added `figure` variant of `oasis-align()`
+    - for when you want to align the images but not the caption text
+- added content ID system to automatically switch from `oasis-align()` to `oasis-align-images()` and `oasis-align-figures()` logic based on input content type
+    - increased performance of image-image and figure-figure alignment 
+    - added `override` parameter to override this behavior
+- major refactoring of codebases
+    - added help functions under `utils.typ`
+    - separated `image` and `figure` variants of `oasis-align()` into separate files
+- `README.md` now includes extra examples of use cases along with tips 
+
 ## 0.3.3 - 2026/01/08
 - fixed relative length issue for gutters
     - thanks to @Andrew15-5 for the fix!

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 To use `oasis-align` in your document, start by importing the package like this:
 ```typst
-#import "@preview/oasis-align:0.3.3": *
+#import "@preview/oasis-align:0.4.0": *
 ```
 and follow the instructions found under [configuration](#function-configuration-parameters).
 
@@ -13,7 +13,7 @@ and follow the instructions found under [configuration](#function-configuration-
 ![Animation of image being aligned with text](docs/image-with-text.gif)
 The same can be done with `figure()` instead of `image()`. 
 ### Image with Image
-This can still be done with `oasis-align()`, but if your content has a fixed aspect ratio like an image, `oasis-align-images()` directly finds a solution. *NOTE: directly passing the image path is depreciated.* 
+`oasis-align()` automatically detects fixed aspect-ratio content like images and figures, using `oasis-align-images()` or `oasis-align-figures()` under the hood to find an exact analytical solution. *NOTE: directly passing the image path is deprecated.* 
 ![Animation of image being aligned with another image](docs/image-with-image.gif)
 ### Text with Text
 ![Animation of text being aligned with differently sized text](docs/text-with-text.gif)
@@ -28,37 +28,54 @@ A large portion of the following parameters have been made user-accessible for e
 #oasis-align(
   swap: false,          // boolean
   vertical: false,      // boolean
-  ruler: false,         // boolean
+  padding: 0pt,         // length, ratio, relative, or array of two
+  override: false,      // boolean
   range: (0, 1),        // array of two decimals between 0 and 1
   int-frac: none,       // decimal between 0 and 1
   int-dir: 1,           // 1 or -1
-  force-frac: none,    // decimal between 0 and 1
+  force-frac: none,     // decimal between 0 and 1
   min-frac: 0.05,       // decimal between 0 and 1
   frac-limit: 1e-5,     // decimal between 0 and 1
-  tolerance: 0.001pt,   // length
+  tolerance: 0.01pt,    // length
   max-iterations: 30,   // integer greater than 0
+  ruler: false,         // boolean
   debug: false,         // boolean
   item1,                // content
   item2,                // content
 )
 
-// IF YOU ARE ALIGNING IMAGES OR OTHER FIXED-ASPECT RATIO CONTENT
+// IF YOU ARE ALIGNING IMAGES OR FIGURES DIRECTLY
 
 #oasis-align-images(
   swap: false,          // boolean
   vertical: false,      // boolean
-  item1,                // fixed-aspect ratio content content
-  item2,                // fixed-aspect ratio content content
+  padding: 0pt,         // length, ratio, relative, or array of two
+  item1,                // image content
+  item2,                // image content
+)
+
+#oasis-align-figures(
+  swap: false,          // boolean
+  vertical: false,      // boolean
+  padding: 0pt,         // length, ratio, relative, or array of two
+  figure1,              // figure content containing an image
+  figure2,              // figure content containing an image
 )
 ```
 
-*IMPORTANT: To change the size of the grid gutter in both functions, use `#set grid(column-gutter: length)`. This is necessary to allow for fixed rules that aren't possible with user-defined functions.*
+*IMPORTANT: To change the size of the grid gutter in all functions, use `#set grid(column-gutter: length)` or `#set grid(row-gutter: length)`. This is necessary to allow for fixed rules that aren't possible with user-defined functions.*
 
 ### `swap` (boolean)
-Swap the positions of `item1` and `item2` on the grid. You can achieve an identical output by manually switching the content of `item1` and `item2`. Note that input parameters such as `forced-frac` and `int-frac` consider the content before it has been swapped.
+Swap the positions of `item1` and `item2` on the grid. You can achieve an identical output by manually switching the content of `item1` and `item2`. *Note that input parameters such as `forced-frac` and `int-frac` consider the content before it has been swapped.*
 
 ### `vertical` (boolean)
 Align the horizontal limits of the content when stacked vertically. This can be particularly useful when aligning images for presentations. 
+
+### `padding` (length, ratio, relative, or array of two)
+Sets padding around the aligned grid (left and right padding when horizontal, top and bottom padding when vertical). Accepts a single length, ratio, or relative value (e.g. `10pt`, `5%`), or an array of two values `(padding-start, padding-end)` for asymmetrical padding.
+
+### `override` (boolean)
+Controls automatic function routing. By default (`override: false`), `oasis-align()` automatically checks if both items are images or figures containing images and routes them to `oasis-align-images()` or `oasis-align-figures()` for direct analytical sizing. Setting `override: true` bypasses automatic routing and forces `oasis-align()` to use its iterative alignment algorithm.
 
 ### `ruler` (boolean)
 Display a ruler overlay on top of the content. Useful for determining fractional values for other input parameters. 
@@ -74,11 +91,10 @@ The starting point of the search process. Changing this value may reduce the tot
 ### `int-dir` (-1 or 1)
 The initial direction that the dividing fraction is moved. Changing this value will change the initial direction.
 
-> [!NOTE]
 > The program is hardcoded to switch directions if a solution is not found in the initial direction. This parameter mainly serves to let you easily choose between [multiple solutions](#multiple-solutions-1st-graph).
 
 ### `force-frac` (decimal between 0 and 1)
-A last resort parameter that bypasses the `oasis-align` algorithm to use the specific fraction. Useful when the function is misbehaving and you just want to display a user-specified layout. 
+A last resort parameter that bypasses the `oasis-align()` algorithm to use the specific fraction. Useful when the function is misbehaving and you just want to display a user-specified layout similar to `grid()`. 
 
 ### `min-frac` (decimal between 0 and 1)
 The minimum fractional width the function will consider during its search. Useful if you do not want to consider solutions that result in very uneven content distribution.
@@ -89,7 +105,6 @@ The minimum difference in fraction values between function iterations. Prevents 
 ### `tolerance` (length)
 The maximum allowable difference in heights between `item1` and `item2`. The function will run until it has reached either this `tolerance` or `max-iterations`. Increasing `tolerance` may reduce the total number of iterations but result in a larger height difference between the pieces of content.  
 
-> [!NOTE]
 > Two pieces of content may not always be able to achieve the desired `tolerance`. In that case, the function sizes the content to the iteration that had the least difference in height. _Check out [how it works](#how-oasis-align-works) to understand why the function may not be able to achieve the desired `tolerance`._
 
 ### `max-iterations` (integer greater than 0)
@@ -106,7 +121,7 @@ Content that is aligned to
 ## Why won't my image align nicely with my text -->
 
 
-## How `oasis-align` Works
+## How `oasis-align()` Works
 Originally designed to allow for an image to be placed side-by-side with text, this function takes an iterative approach to aligning the content. When changing the width of a block of text, the height does not scale linearly, but instead behaves as a step function that follows an exponential trend (the graph below has a simplified visualization of this). This prevents the use of an analytical methodology and thus must be solved using an iterative approach.
 
 The function starts by taking the available space and then splitting it using the `int-frac`. The content is then placed in a block with the width as determined using the split from `int-frac` before measuring its height. Based on the `int-dir`, the split will be moved left or right using the bisection method until a solution within the `tolerance` has been found. In the case that a solution within the `tolerance` is not found within the `max-iterations`, the program terminates and uses the container width fraction that had the smallest difference in height. 
@@ -122,12 +137,15 @@ There are cases in which the text size is incompatible with an image. This can b
 ### Tolerance Not Reached (3rd Graph)
 In the case of having texts of different sizes (as seen in [the examples](#text-with-text)), the spacing between lines prevents the function from finding a solution that meets the `tolerance` and thus the closest solution is used.
 
-## How `oasis-align-images` Works
-The function begins by determining the width and height of the selected images. These values can then be used to solve a set of linear equations, the first of which states that the sum of the widths of the images (plus the gutter) should be equal to the available horizontal space, and the second which states that their heights should be equal.  
+## How `oasis-align-images()` & `oasis-align-figures()` Work
+The function begins by determining the aspect ratio of the selected images or figures containing images. These values can then be used to solve a set of linear equations, the first of which states that the sum of the widths of the images (plus the gutter and padding) should be equal to the available horizontal space, and the second which states that their heights should be equal.  
 
 If $w_1$ and $h_1$ are the width and height of `image1` and $w_2$ and $h_2$ are the width and height of `image2`, then the final width $w_1'$ of `image1` and the final width $w_2'$ of `image2` are
 
 $$w_1' = \left(\frac{h_1 w_2}{w_1 h_2} + 1 \right)^{-1} \qquad w_2' = \left(\frac{w_1 h_2}{h_1 w_2} + 1 \right)^{-1}$$
+
+`oasis-align-figures()` is unique in that it isolates the image from the caption, avoiding situations where a lengthy caption might cause wrapped text and different height images.
+
 <!-- # Nomenclature
 "Oasis" as in a fertile spot in a desert, where water is found. -->
 

--- a/demo/demo.typ
+++ b/demo/demo.typ
@@ -13,6 +13,23 @@
 #let words = [This is me writing about my cat. I love my cat. He is the best of cats. I give him head scratches until he gets mad at me. He then he starts swatting at my hand. This goes on until my hand gets scratched.]
 
 #let cat = image("blanket.jpg")
+#let cat-fig = [#figure(
+  cat, 
+  caption: [This is a caption]
+) <thihng>]
+
+// #cat.func()
+// #cat-fig.func()
+#cat-fig.fields()
+#repr(cat-fig)
+
+#type(cat-fig)
+
+
+#cat-fig.has("label")
+
+// #cat-fig.body.func()
+
 
 // #place(line(length: 2in, angle: 90deg, stroke: 5pt))
 
@@ -36,17 +53,16 @@
   // margin: (0in, 5pt),
   // int-dir: -1, 
   // force1: true,
-  // range: (0.5, 1),
+  range: (0.5, 1),
   // range: (0, .75),
   // int-frac: .6,
-  // forced-frac: .4, 
+  // force-frac: .4, 
   // int-frac: .46,
   // max-iterations: 100,
   // min-frac: .2,
   // debug: true,
   // swap: true,
-  // show-ruler: true,
-  ruler: true,
+  // ruler: true,
   cat, 
   words
 )

--- a/demo/demo.typ
+++ b/demo/demo.typ
@@ -1,6 +1,9 @@
-#import "../oasis-align.typ": *
+// #import "../oasis-align.typ": *
+// #import "../oasis-align-images.typ": *
+#import "../lib.typ": *
 // #import "@preview/oasis-align:0.2.0": *
 // #import "@local/oasis-align:0.2.0": *
+// 
 
 #set page(width: 6in, height: auto, margin: 1in)
 #set par(justify: true)
@@ -23,30 +26,30 @@
 // #type(cat)
 
 // #image("blanket.jpg", width: 6% + 1in)
-// #oasis-align(
-//   // margin: 6% ,
-//   // margin: 20pt + 5%,
-//   // margin: 9pt,
-//   margin: (15pt + 3em, 5pt + 7%),
-//   // margin: (0in, 5pt),
-//   // margin: (1in, 5pt),
-//   // margin: (0in, 5pt),
-//   // int-dir: -1, 
-//   // force1: true,
-//   // range: (0.5, 1),
-//   // range: (0, .75),
-//   // int-frac: .6,
-//   // forced-frac: .4, 
-//   // int-frac: .46,
-//   // max-iterations: 100,
-//   // min-frac: .2,
-//   // debug: true,
-//   // swap: true,
-//   // show-ruler: true,
-//   ruler: true,
-//   cat, 
-//   words
-// )
+#oasis-align(
+  // margin: 6% ,
+  // margin: 20pt + 5%,
+  // margin: 9pt,
+  margin: (15pt + 3em, 5pt + 7%),
+  // margin: (0in, 5pt),
+  // margin: (1in, 5pt),
+  // margin: (0in, 5pt),
+  // int-dir: -1, 
+  // force1: true,
+  // range: (0.5, 1),
+  // range: (0, .75),
+  // int-frac: .6,
+  // forced-frac: .4, 
+  // int-frac: .46,
+  // max-iterations: 100,
+  // min-frac: .2,
+  // debug: true,
+  // swap: true,
+  // show-ruler: true,
+  ruler: true,
+  cat, 
+  words
+)
 
 // #v(3em)
 // // #grid(columns: (1fr, 1.19fr),  
@@ -65,7 +68,7 @@
 //   image("blanket.jpg"), 
 //   image("box.jpg"),
 // )
-
+// #set grid(gutter: 2em)
 #oasis-align-images(
   // debug: true,
   // int-dir: -1,
@@ -73,7 +76,7 @@
   // swap: true,
   // min-frac: 0.2,
   // ruler: true,
-  margin: (30pt, 30%),
+  // margin: (30pt, 30%),
   image("blanket.jpg"), 
   image("box.jpg"),
   // path("blanket.jpg"), 

--- a/demo/demo.typ
+++ b/demo/demo.typ
@@ -17,7 +17,7 @@
 #oasis-align(
   // margin: 9pt,
   // margin: 9pt,
-  margin: (15pt, 0pt),
+  margin: (15pt, 100pt),
   // margin: (0in, 5pt),
   // margin: (1in, 5pt),
   // margin: (0in, 5pt),

--- a/demo/demo.typ
+++ b/demo/demo.typ
@@ -23,30 +23,30 @@
 // #type(cat)
 
 // #image("blanket.jpg", width: 6% + 1in)
-#oasis-align(
-  // margin: 6% ,
-  // margin: 20pt + 5%,
-  // margin: 9pt,
-  margin: (15pt + 3em, 5pt + 7%),
-  // margin: (0in, 5pt),
-  // margin: (1in, 5pt),
-  // margin: (0in, 5pt),
-  // int-dir: -1, 
-  // force1: true,
-  // range: (0.5, 1),
-  // range: (0, .75),
-  // int-frac: .6,
-  // forced-frac: .4, 
-  // int-frac: .46,
-  // max-iterations: 100,
-  // min-frac: .2,
-  // debug: true,
-  // swap: true,
-  // show-ruler: true,
-  ruler: true,
-  cat, 
-  words
-)
+// #oasis-align(
+//   // margin: 6% ,
+//   // margin: 20pt + 5%,
+//   // margin: 9pt,
+//   margin: (15pt + 3em, 5pt + 7%),
+//   // margin: (0in, 5pt),
+//   // margin: (1in, 5pt),
+//   // margin: (0in, 5pt),
+//   // int-dir: -1, 
+//   // force1: true,
+//   // range: (0.5, 1),
+//   // range: (0, .75),
+//   // int-frac: .6,
+//   // forced-frac: .4, 
+//   // int-frac: .46,
+//   // max-iterations: 100,
+//   // min-frac: .2,
+//   // debug: true,
+//   // swap: true,
+//   // show-ruler: true,
+//   ruler: true,
+//   cat, 
+//   words
+// )
 
 // #v(3em)
 // // #grid(columns: (1fr, 1.19fr),  
@@ -73,6 +73,7 @@
   // swap: true,
   // min-frac: 0.2,
   // ruler: true,
+  margin: .5in,
   image("blanket.jpg"), 
   image("box.jpg"),
   // path("blanket.jpg"), 

--- a/demo/demo.typ
+++ b/demo/demo.typ
@@ -13,15 +13,25 @@
 
 // #place(line(length: 2in, angle: 90deg, stroke: 5pt))
 
+// #let thing = 1pt + 0%
+// #type(thing)
+// #thing.length
+// #thing.ratio
 
+// #repr(cat)
+// #cat.source
+// #type(cat)
+
+// #image("blanket.jpg", width: 6% + 1in)
 #oasis-align(
+  // margin: 6% ,
+  // margin: 20pt + 5%,
   // margin: 9pt,
-  // margin: 9pt,
-  margin: (15pt, 100pt),
+  margin: (15pt, 50pt),
   // margin: (0in, 5pt),
   // margin: (1in, 5pt),
   // margin: (0in, 5pt),
-  // int-dir: 1, 
+  // int-dir: -1, 
   // force1: true,
   // range: (0.5, 1),
   // range: (0, .75),

--- a/demo/demo.typ
+++ b/demo/demo.typ
@@ -15,6 +15,12 @@
 
 
 #oasis-align(
+  // margin: 9pt,
+  // margin: 9pt,
+  margin: (15pt, 0pt),
+  // margin: (0in, 5pt),
+  // margin: (1in, 5pt),
+  // margin: (0in, 5pt),
   // int-dir: 1, 
   // force1: true,
   // range: (0.5, 1),
@@ -32,23 +38,23 @@
   words
 )
 
-#v(3em)
-// #grid(columns: (1fr, 1.19fr),  
-//   cat, 
-//   words
-// )
+// #v(3em)
+// // #grid(columns: (1fr, 1.19fr),  
+// //   cat, 
+// //   words
+// // )
 
-#oasis-align(
-  // debug: true,
-  int-dir: -1,
-  force-frac: .5,
-  // vertical: true,
-  // swap: true,
-  // min-frac: 0.2,
-  ruler: true,
-  image("blanket.jpg"), 
-  image("box.jpg"),
-)
+// #oasis-align(
+//   // debug: true,
+//   int-dir: -1,
+//   force-frac: .5,
+//   // vertical: true,
+//   // swap: true,
+//   // min-frac: 0.2,
+//   ruler: true,
+//   image("blanket.jpg"), 
+//   image("box.jpg"),
+// )
 
 #oasis-align-images(
   // debug: true,
@@ -59,6 +65,10 @@
   // ruler: true,
   image("blanket.jpg"), 
   image("box.jpg"),
+  // path("blanket.jpg"), 
+  // path("box.jpg"),
+  // "blanket.jpg", 
+  // "box.jpg",
 )
 
 #oasis-align(
@@ -97,6 +107,7 @@
 #oasis-align(
   vertical: true,
   swap: true,
+  margin: (0pt, 5pt),
   image("blanket.jpg"),
   image("box.jpg"),
 )

--- a/demo/demo.typ
+++ b/demo/demo.typ
@@ -27,7 +27,7 @@
   // margin: 6% ,
   // margin: 20pt + 5%,
   // margin: 9pt,
-  margin: (15pt, 50pt),
+  margin: (15pt + 3em, 5pt + 7%),
   // margin: (0in, 5pt),
   // margin: (1in, 5pt),
   // margin: (0in, 5pt),

--- a/demo/demo.typ
+++ b/demo/demo.typ
@@ -1,9 +1,4 @@
-// #import "../oasis-align.typ": *
-// #import "../oasis-align-images.typ": *
 #import "../lib.typ": *
-// #import "@preview/oasis-align:0.2.0": *
-// #import "@local/oasis-align:0.2.0": *
-// 
 
 #set page(width: 6in, height: auto, margin: 1in)
 #set par(justify: true)
@@ -11,43 +6,16 @@
 #set grid(column-gutter: 4%)
 
 #let words = [This is me writing about my cat. I love my cat. He is the best of cats. I give him head scratches until he gets mad at me. He then he starts swatting at my hand. This goes on until my hand gets scratched.]
-
 #let cat = image("blanket.jpg")
 #let cat-fig = [#figure(
   cat, 
   caption: [This is a caption]
 ) <thihng>]
 
-// #cat.func()
-// #cat-fig.func()
-// #cat-fig.fields()
-// #repr(cat-fig)
 
-#cat-fig.children.at(0).func()
-#cat-fig.func()
-#type(cat-fig)
-
-
-// #cat-fig.has("label")
-
-// #cat-fig.body.func()
-
-
-// #place(line(length: 2in, angle: 90deg, stroke: 5pt))
-
-// #let thing = 1pt + 0%
-// #type(thing)
-// #thing.length
-// #thing.ratio
-
-// #repr(cat)
-// #cat.source
-// #type(cat)
-
-// #image("blanket.jpg", width: 6% + 1in)
-
-
-#oasis-align-figures(
+#oasis-align(
+  // debug: true,
+  // override: true,
   // margin: 50pt, 
   [#figure(
     cat,
@@ -58,8 +26,6 @@
     caption: [],
   )
 )
-
-
 
 #oasis-align(
   // margin: 6% ,
@@ -85,19 +51,6 @@
   words
 )
 
-// #v(3em)
-// // #grid(columns: (1fr, 1.19fr),  
-// //   cat, 
-// //   words
-// // )
-
-// #type("sdfsdf")
-
-// #{cat.func() == image}
-// // #{cat.has(func)}
-// #{cat.at("func", default: none) == image}
-// #{cat.has(func)}
-
 #oasis-align(
   debug: true,
   int-dir: -1,
@@ -109,6 +62,7 @@
   image("blanket.jpg"), 
   image("box.jpg"),
 )
+
 // #set grid(gutter: 2em)
 // #oasis-align-images(
 //   // debug: true,

--- a/demo/demo.typ
+++ b/demo/demo.typ
@@ -91,33 +91,40 @@
 // //   words
 // // )
 
-// #oasis-align(
-//   // debug: true,
-//   int-dir: -1,
-//   force-frac: .5,
-//   // vertical: true,
-//   // swap: true,
-//   // min-frac: 0.2,
-//   ruler: true,
-//   image("blanket.jpg"), 
-//   image("box.jpg"),
-// )
-// #set grid(gutter: 2em)
-#oasis-align-images(
-  // debug: true,
-  // int-dir: -1,
+// #type("sdfsdf")
+
+// #{cat.func() == image}
+// // #{cat.has(func)}
+// #{cat.at("func", default: none) == image}
+// #{cat.has(func)}
+
+#oasis-align(
+  debug: true,
+  int-dir: -1,
+  // force-frac: .5,
   // vertical: true,
   // swap: true,
   // min-frac: 0.2,
   // ruler: true,
-  // margin: (30pt, 30%),
   image("blanket.jpg"), 
   image("box.jpg"),
-  // path("blanket.jpg"), 
-  // path("box.jpg"),
-  // "blanket.jpg", 
-  // "box.jpg",
 )
+// #set grid(gutter: 2em)
+// #oasis-align-images(
+//   // debug: true,
+//   // int-dir: -1,
+//   // vertical: true,
+//   // swap: true,
+//   // min-frac: 0.2,
+//   // ruler: true,
+//   // margin: (30pt, 30%),
+//   image("blanket.jpg"), 
+//   image("box.jpg"),
+//   // path("blanket.jpg"), 
+//   // path("box.jpg"),
+//   // "blanket.jpg", 
+//   // "box.jpg",
+// )
 
 #oasis-align(
   // debug: true,

--- a/demo/demo.typ
+++ b/demo/demo.typ
@@ -20,13 +20,15 @@
 
 // #cat.func()
 // #cat-fig.func()
-#cat-fig.fields()
-#repr(cat-fig)
+// #cat-fig.fields()
+// #repr(cat-fig)
 
+#cat-fig.children.at(0).func()
+#cat-fig.func()
 #type(cat-fig)
 
 
-#cat-fig.has("label")
+// #cat-fig.has("label")
 
 // #cat-fig.body.func()
 
@@ -43,6 +45,22 @@
 // #type(cat)
 
 // #image("blanket.jpg", width: 6% + 1in)
+
+
+#oasis-align-figures(
+  // margin: 50pt, 
+  [#figure(
+    cat,
+    caption: [caption1 is really long and ],
+  ) <sdfs>],
+  figure(
+    image("box.jpg"),
+    caption: [],
+  )
+)
+
+
+
 #oasis-align(
   // margin: 6% ,
   // margin: 20pt + 5%,

--- a/demo/demo.typ
+++ b/demo/demo.typ
@@ -16,7 +16,7 @@
 #oasis-align(
   // debug: true,
   // override: true,
-  // margin: 50pt, 
+  // padding: 50pt, 
   [#figure(
     cat,
     caption: [caption1 is really long and ],
@@ -28,13 +28,13 @@
 )
 
 #oasis-align(
-  // margin: 6% ,
-  // margin: 20pt + 5%,
-  // margin: 9pt,
-  margin: (15pt + 3em, 5pt + 7%),
-  // margin: (0in, 5pt),
-  // margin: (1in, 5pt),
-  // margin: (0in, 5pt),
+  // padding: 6% ,
+  // padding: 20pt + 5%,
+  // padding: 9pt,
+  padding: (15pt + 3em, 5pt + 7%),
+  // padding: (0in, 5pt),
+  // padding: (1in, 5pt),
+  // padding: (0in, 5pt),
   // int-dir: -1, 
   // force1: true,
   range: (0.5, 1),
@@ -71,7 +71,7 @@
 //   // swap: true,
 //   // min-frac: 0.2,
 //   // ruler: true,
-//   // margin: (30pt, 30%),
+//   // padding: (30pt, 30%),
 //   image("blanket.jpg"), 
 //   image("box.jpg"),
 //   // path("blanket.jpg"), 
@@ -116,7 +116,7 @@
 #oasis-align(
   vertical: true,
   swap: true,
-  margin: (0pt, 5pt),
+  padding: (0pt, 5pt),
   image("blanket.jpg"),
   image("box.jpg"),
 )

--- a/demo/demo.typ
+++ b/demo/demo.typ
@@ -73,7 +73,7 @@
   // swap: true,
   // min-frac: 0.2,
   // ruler: true,
-  margin: .5in,
+  margin: (30pt, 30%),
   image("blanket.jpg"), 
   image("box.jpg"),
   // path("blanket.jpg"), 

--- a/lib.typ
+++ b/lib.typ
@@ -1,0 +1,3 @@
+#import "oasis-align.typ": oasis-align
+#import "oasis-align-images.typ": oasis-align-images
+// #import "oasis-align-figures.typ": oasis-align-figures

--- a/lib.typ
+++ b/lib.typ
@@ -1,3 +1,3 @@
 #import "oasis-align.typ": oasis-align
 #import "oasis-align-images.typ": oasis-align-images
-// #import "oasis-align-figures.typ": oasis-align-figures
+#import "oasis-align-figures.typ": oasis-align-figures

--- a/oasis-align-figures.typ
+++ b/oasis-align-figures.typ
@@ -3,7 +3,7 @@
 #let oasis-align-figures(
   vertical: false,
   swap: false, 
-  margin: 0pt,
+  padding: 0pt,
   figure1, 
   figure2
 ) = context {
@@ -30,16 +30,16 @@
   layout(measured-container => {
     // Measure size of container
     let container-side = if vertical { measured-container.height } else { measured-container.width }
-    let margins = process-margin(margin, container-side)
+    let paddings = process-padding(padding, container-side)
     let gutter = process-gutter(vertical, container-side)
     let ratio = find-image-ratio(figure1, figure2, vertical)
     
-    let max-dim = container-side - gutter - margins.first() - margins.last()
+    let max-dim = container-side - gutter - paddings.first() - paddings.last()
     // Set widths of images
     let calcWidth1 = (max-dim)/(1/ratio + 1)
     let calcWidth2 = (max-dim)/(ratio + 1)
 
     // Display images in grid
-    display-output(figure1, figure2, calcWidth1, calcWidth2, vertical, swap, margins, false, 0pt)
+    display-output(figure1, figure2, calcWidth1, calcWidth2, vertical, swap, paddings, false, 0pt)
   })
 }

--- a/oasis-align-figures.typ
+++ b/oasis-align-figures.typ
@@ -1,0 +1,45 @@
+#import "utils.typ": *
+
+#let oasis-align-figures(
+  vertical: false,
+  swap: false, 
+  margin: 0pt,
+  figure1, 
+  figure2
+) = context {
+
+  assert(type(vertical) == bool, message: "Vertical parameter condition must be true or false!")
+  assert(type(swap) == bool, message: "Swap parameter must be true or false!")
+
+  let extract-image(input) = {
+    assert(type(input) == content, message: "Arguments must be figures!")
+
+    if input.func() == figure {
+      if input.body.func() == image {input.body.func()}
+      else {panic("Figures must contain images! Otherwise, use `oasis-align`.")}
+    }
+    else if input.children.at(0).func() == figure {
+      if input.children.at(0).body.func() == image {input.children.at(0).body.func()}
+      else {panic("Figures must contain images! Otherwise, use `oasis-align`.")}
+    }
+    else {panic("Arguments must be figures!")}
+  }
+
+  let (image1, image2) =  {(figure1, figure2).map(it => extract-image(it))}
+
+  layout(measured-container => {
+    // Measure size of container
+    let container-side = if vertical { measured-container.height } else { measured-container.width }
+    let margins = process-margin(margin, container-side)
+    let gutter = process-gutter(vertical, container-side)
+    let ratio = find-image-ratio(figure1, figure2, vertical)
+    
+    let max-dim = container-side - gutter - margins.first() - margins.last()
+    // Set widths of images
+    let calcWidth1 = (max-dim)/(1/ratio + 1)
+    let calcWidth2 = (max-dim)/(ratio + 1)
+
+    // Display images in grid
+    display-output(figure1, figure2, calcWidth1, calcWidth2, vertical, swap, margins, false, 0pt)
+  })
+}

--- a/oasis-align-images.typ
+++ b/oasis-align-images.typ
@@ -1,5 +1,6 @@
 #import "utils.typ": *
 
+
 #let oasis-align-images(
   vertical: false,
   swap: false, 
@@ -17,12 +18,7 @@
     let container-side = if vertical { measured-container.height } else { measured-container.width }
     let margins = process-margin(margin, container-side)
     let gutter = process-gutter(vertical, container-side)
-
-    // Find dimensional ratio between images
-    let block1 = measure(image1)
-    let block2 = measure(image2)
-    let ratio = if vertical {(block1.height/block1.width)*block2.width/block2.height}
-                else {(block1.width/block1.height)*block2.height/block2.width}
+    let ratio = find-image-ratio(image1, image2, vertical)
     
     let max-dim = container-side - gutter - margins.first() - margins.last()
     // Set widths of images

--- a/oasis-align-images.typ
+++ b/oasis-align-images.typ
@@ -3,7 +3,7 @@
 #let oasis-align-images(
   vertical: false,
   swap: false, 
-  margin: 0pt,
+  padding: 0pt,
   image1, 
   image2
 ) = context {
@@ -16,16 +16,16 @@
   layout(measured-container => {
     // Measure size of container
     let container-side = if vertical { measured-container.height } else { measured-container.width }
-    let margins = process-margin(margin, container-side)
+    let paddings = process-padding(padding, container-side)
     let gutter = process-gutter(vertical, container-side)
     let ratio = find-image-ratio(image1, image2, vertical)
     
-    let max-dim = container-side - gutter - margins.first() - margins.last()
+    let max-dim = container-side - gutter - paddings.first() - paddings.last()
     // Set widths of images
     let calcWidth1 = (max-dim)/(1/ratio + 1)
     let calcWidth2 = (max-dim)/(ratio + 1)
 
     // Display images in grid
-    display-output(image1, image2, calcWidth1, calcWidth2, vertical, swap, margins, false, 0pt)
+    display-output(image1, image2, calcWidth1, calcWidth2, vertical, swap, paddings, false, 0pt)
   })
 }

--- a/oasis-align-images.typ
+++ b/oasis-align-images.typ
@@ -1,0 +1,35 @@
+#import "utils.typ": *
+
+#let oasis-align-images(
+  vertical: false,
+  swap: false, 
+  margin: 0pt,
+  image1, 
+  image2
+) = context {
+
+  assert(type(vertical) == bool, message: "Vertical parameter condition must be true or false!")
+  assert(type(swap) == bool, message: "Swap parameter must be true or false!")
+
+  
+  layout(measured-container => {
+    // Measure size of container
+    let container-side = if vertical { measured-container.height } else { measured-container.width }
+    let margins = process-margin(margin, container-side)
+    let gutter = process-gutter(vertical, container-side)
+
+    // Find dimensional ratio between images
+    let block1 = measure(image1)
+    let block2 = measure(image2)
+    let ratio = if vertical {(block1.height/block1.width)*block2.width/block2.height}
+                else {(block1.width/block1.height)*block2.height/block2.width}
+    
+    let max-dim = container-side - gutter - margins.first() - margins.last()
+    // Set widths of images
+    let calcWidth1 = (max-dim)/(1/ratio + 1)
+    let calcWidth2 = (max-dim)/(ratio + 1)
+
+    // Display images in grid
+    display-output(image1, image2, calcWidth1, calcWidth2, vertical, swap, margins, false, 0pt)
+  })
+}

--- a/oasis-align-images.typ
+++ b/oasis-align-images.typ
@@ -10,7 +10,7 @@
 
   assert(type(vertical) == bool, message: "Vertical parameter condition must be true or false!")
   assert(type(swap) == bool, message: "Swap parameter must be true or false!")
-  
+  assert((image1, image2).any(input => type(input) == content and input.func() == image), message: "Input arguments must be images!")
 
   
   layout(measured-container => {

--- a/oasis-align-images.typ
+++ b/oasis-align-images.typ
@@ -1,6 +1,5 @@
 #import "utils.typ": *
 
-
 #let oasis-align-images(
   vertical: false,
   swap: false, 
@@ -11,6 +10,7 @@
 
   assert(type(vertical) == bool, message: "Vertical parameter condition must be true or false!")
   assert(type(swap) == bool, message: "Swap parameter must be true or false!")
+  
 
   
   layout(measured-container => {

--- a/oasis-align.typ
+++ b/oasis-align.typ
@@ -1,3 +1,5 @@
+#import "utils.typ": *
+
 #let oasis-align(
   vertical: false,
   swap: false,
@@ -21,7 +23,6 @@
   // Check that inputs are valid
   assert(type(vertical) == bool, message: "Vertical parameter condition must be true or false!")
   assert(type(swap) == bool, message: "Swap parameter must be true or false!")
-  // assert(ty)
   assert(type(range) == array and range.len() == 2 and range.all(it => check-fraction(it)), message: "Range must be an array of two fractions!")
   assert(int-dir == -1 or int-dir == 1, message: "Initial direction parameter must be 1 or -1!")
   assert(int-frac == none or check-fraction(int-frac), message:"Initial fraction must be between 0 and 1!")
@@ -33,7 +34,7 @@
   assert(type(max-iterations) == int, message: "The maximum number of iterations must be an integer! Lowering the number may find a solution quicker, but it may no be within tolerance.")
   assert(type(ruler) == bool, message: "Ruler can be turned on or off only using boolean!")
   assert(type(debug) == bool, message: "Debug feed can be turned on or off only using boolean!")
-
+  
 
   // Debug functions
   let heads-up(message) = if debug {block(text(blue, weight: "bold", message))}
@@ -55,42 +56,8 @@
 
     // Relevant container side, depending on `vertical`.
     let container-side = if vertical { measured-container.height } else { measured-container.width }
-    let grid-gutter = if vertical {grid.row-gutter} else {grid.column-gutter}
-
-    let gutter = {
-      // In case grid.gutter is not defined, otherwise get first track sizing.
-      let gutter = if grid-gutter == () {0% + 0pt} else {grid-gutter.first()}
-      // In case grid.gutter is `int`, `auto`, `fraction`, ignore the value.
-      if gutter == auto or type(gutter) == fraction { gutter = 0% + 0pt }
-      // Convert `relative` length to absolute `length`.
-      gutter = container-side * gutter.ratio + gutter.length.to-absolute()
-      gutter
-    }
-
-    let process-margin(m) = {
-      if type(m) == length {
-        m.to-absolute()
-      } else if type(m) == ratio {
-        m * container-side
-      } else if type(m) == relative {
-        m.ratio * container-side + m.length.to-absolute()
-      } else {
-        panic("Incorrect margin entry type: expected length, ratio, or relative, got " + str(type(m)))
-      }
-    }
-
-    let margins = {
-      if type(margin) == array {
-        if margin.len() != 2 {
-          panic("Margin array must contain exactly two entries!")
-        }
-        (process-margin(margin.at(0)), process-margin(margin.at(1)))
-      } else {
-        let calc-margin = process-margin(margin)
-        (calc-margin, calc-margin)
-      }
-    }
-
+    let margins = process-margin(margin, container-side)
+    let gutter = process-gutter(vertical, container-side)
 
     let max-dim = container-side - gutter - margins.first() - margins.last()
     let dim-1a    // Bounding dimension of item1
@@ -117,124 +84,6 @@
       return (dim1, dim2)
     }
 
-    let measure-difference(dim1, dim2, vertical) = {
-      let out1 
-      let out2 
-      if vertical {
-        out1 = measure(block(height: dim1, item1)).width.to-absolute()
-        out2 = measure(block(height: dim2, item2)).width.to-absolute()
-      } else {
-        out1 = measure(block(width: dim1, item1)).height.to-absolute()
-        out2 = measure(block(width: dim2, item2)).height.to-absolute()
-      }
-      let diff = calc.abs(out1 - out2)
-
-      return (out1, out2, diff)
-    }
-
-    let show-ruler(
-      ruler-dim, 
-      vertical, 
-      ratio: .7, 
-      color: red.transparentize(20%)
-    ) = {
-      if ruler == false {return}
-      
-      let stack-direction
-      let line-angle
-
-      if vertical {
-        stack-direction = ttb
-        line-angle = 0deg
-      } else {
-        stack-direction = ltr
-        line-angle = 90deg
-      }
-
-      let major-line  = line(
-        length: ruler-dim * ratio, 
-        angle: line-angle, 
-        stroke: (thickness: .4em, paint: color, cap: "round")
-      )
-
-      let median-line = line(
-        length: ruler-dim * ratio * .8, 
-        angle: line-angle, 
-        stroke: (thickness: .3em, paint: color, cap: "round")
-      )
-
-      let minor-line  = line(
-        length: ruler-dim * ratio * .5, 
-        angle: line-angle, 
-        stroke: (thickness: .3em, paint: color, cap: "round")
-      )
-      
-      place(
-        horizon + center,
-        stack(
-          dir: stack-direction, 
-          spacing: 10%,
-          major-line, 
-          minor-line, minor-line, minor-line, minor-line,
-          major-line,
-          minor-line, minor-line, minor-line, minor-line,
-          major-line,
-        )
-      )
-      
-      place(
-        horizon + center,
-        line(length: 100%, angle: calc.abs(line-angle - 90deg), stroke: (thickness: 3pt, paint: color, cap: "round"))
-      )
-    }
-
-    let display-output(dim1, dim2, vertical, swap, ruler-dim) = {
-      if vertical {
-        if swap {
-          pad(
-            top: margins.first(),
-            bottom: margins.last(),
-            {
-              grid(rows: (dim2, dim1), item2, item1)
-              show-ruler(ruler-dim, vertical)
-            }
-          )
-          }
-        else    {
-          pad(
-            top: margins.first(),
-            bottom: margins.last(),
-            {
-              grid(rows: (dim1, dim2), item1, item2)
-              show-ruler(ruler-dim, vertical)
-            }
-          )
-          }
-      }
-      else {
-        if swap {
-          pad(
-            left: margins.first(),
-            right: margins.last(),
-            {
-              grid(columns: (dim2, dim1), item2, item1)
-              show-ruler(ruler-dim, vertical)
-            }
-          )
-          }
-        else    {
-          pad(
-            left: margins.first(),
-            right: margins.last(),
-            {
-              grid(columns: (dim1, dim2), item1, item2)
-              show-ruler(ruler-dim, vertical)
-            }
-          )
-          }
-      }
-    }
-
     // Loop max to prevent infinite loop
     while n < max-iterations {
       n = n + 1
@@ -259,7 +108,7 @@
       }
 
       // Measure height of content and find difference
-      (dim-1b, dim-2b, diff) = measure-difference(dim-1a, dim-2a, vertical) 
+      (dim-1b, dim-2b, diff) = measure-difference(item1, item2, dim-1a, dim-2a, vertical) 
       
       system-info()[
           // item1: (#dim-1a, #dim-1b) \ 
@@ -290,7 +139,7 @@
       // Check if within tolerance. If so, display
       if diff < tolerance or n >= max-iterations or dir-change >= 2 or override {
         success([Displaying output...])
-        display-output(dim-1a, dim-2a, vertical, swap, dim-1b)
+        display-output(item1, item2, dim-1a, dim-2a, vertical, swap, margins, ruler, dim-1b)
         break
       }
       // Use bisection method by setting new bounds
@@ -323,106 +172,5 @@
         frac = best-frac
       }
     }
-  })
-}
-
-#let oasis-align-images(
-  vertical: false,
-  swap: false, 
-  margin: 0pt,
-  image1, 
-  image2
-) = context {
-
-  
-  layout(measured-container => {
-    // Measure size of continaner
-    // let container = size.width
-    let container-side = if vertical { measured-container.height } else { measured-container.width }
-    let grid-gutter = if vertical {grid.row-gutter} else {grid.column-gutter}
-    
-    let gutter = {
-      // In case grid.gutter is not defined, otherwise get first track sizing.
-      let gutter = if grid-gutter == () {0% + 0pt} else {grid-gutter.first()}
-      // In case grid.gutter is `int`, `auto`, `fraction`, ignore the value.
-      if gutter == auto or type(gutter) == fraction { gutter = 0% + 0pt }
-      // Convert `relative` length to absolute `length`.
-      gutter = container-side * gutter.ratio + gutter.length.to-absolute()
-      gutter
-    }
-
-    let process-margin(m) = {
-      if type(m) == length {
-        m.to-absolute()
-      } else if type(m) == ratio {
-        m * container-side
-      } else if type(m) == relative {
-        m.ratio * container-side + m.length.to-absolute()
-      } else {
-        panic("Incorrect margin entry type: expected length, ratio, or relative, got " + str(type(m)))
-      }
-    }
-
-    let margins = {
-      if type(margin) == array {
-        if margin.len() != 2 {
-          panic("Margin array must contain exactly two entries!")
-        }
-        (process-margin(margin.at(0)), process-margin(margin.at(1)))
-      } else {
-        let calc-margin = process-margin(margin)
-        (calc-margin, calc-margin)
-      }
-    }
-
-    
-    let display-output(dim1, dim2, vertical, swap) = {
-      if vertical {
-        if swap {
-          pad(
-            top: margins.first(),
-            bottom: margins.last(),
-            grid(rows: (dim2, dim1), image2, image1)
-          )
-        }
-        else {
-          pad(
-            top: margins.first(),
-            bottom: margins.last(),
-            grid(rows: (dim1, dim2), image1, image2)
-          )
-        }
-      }
-      else {
-        if swap {
-          pad(
-            left: margins.first(),
-            right: margins.last(),
-            grid(columns: (dim2, dim1), image2, image1)
-          )
-        }
-        else {
-          pad(
-            left: margins.first(),
-            right: margins.last(),
-            grid(columns: (dim1, dim2), image1, image2)
-          )
-        }
-      }
-    }
-
-      // Find dimentional ratio between images
-    let block1 = measure(image1)
-    let block2 = measure(image2)
-    let ratio = if vertical {(block1.height/block1.width)*block2.width/block2.height}
-                else {(block1.width/block1.height)*block2.height/block2.width}
-    
-    let max-dim = container-side - gutter - margins.first() - margins.last()
-    // Set widths of images
-    let calcWidth1 = (max-dim)/(1/ratio + 1)
-    let calcWidth2 = (max-dim)/(ratio + 1)
-
-    // Display images in grid
-    display-output(calcWidth1, calcWidth2, vertical, swap)
   })
 }

--- a/oasis-align.typ
+++ b/oasis-align.typ
@@ -57,6 +57,7 @@
     let side = if vertical {"height"} else {"width"}
     let container-side = measured-container.at(side)
     let grid-gutter = if vertical {grid.row-gutter} else {grid.column-gutter}
+
     let gutter = {
       // In case grid.gutter is not defined, otherwise get first track sizing.
       let gutter = if grid-gutter == () {0% + 0pt} else {grid-gutter.first()}
@@ -66,11 +67,21 @@
       gutter = container-side * gutter.ratio + gutter.length.to-absolute()
       gutter
     }
+
     let margins = {
       if type(margin) == length {
-        (margin, margin)
+        (margin.to-absolute(), margin.to-absolute())
+      } else if type(margin) == ratio {
+        let calc-margin = margin * container-side
+        (calc-margin, calc-margin)
+      } else if type(margin) == relative {
+        let calc-margin = margin.ratio * container-side + margin.length.to-absolute()
+        (calc-margin, calc-margin)
       } else if type(margin) == array {
+        if margin.flatten().len() != 2 {panic("Margin array should only have two entries!")}
         margin
+      } else {
+        panic("Incorrect margin parameter type. Please use a length, ratio, or relative!")
       }
     }
 
@@ -312,6 +323,7 @@
 #let oasis-align-images(
   vertical: false,
   swap: false, 
+  margin: 0in,
   image1, 
   image2
 ) = context {

--- a/oasis-align.typ
+++ b/oasis-align.typ
@@ -1,6 +1,6 @@
 #import "utils.typ": *
-// #import "oasis-align-images.typ": oasis-align-images
-// #import "oasis-align-figures.typ": oasis-align-figures
+#import "oasis-align-images.typ": oasis-align-images
+#import "oasis-align-figures.typ": oasis-align-figures
 
 #let oasis-align(
   vertical: false,
@@ -51,6 +51,25 @@
   assert(type(ruler) == bool, message: "Ruler can be turned on or off only using boolean!")
   assert(type(debug) == bool, message: "Debug feed can be turned on or off only using boolean!")
   
+  let check-if-image(input) = {
+    if type(input) == content {
+        success("Content identified as image! Using `oasis-align-images` instead.")
+      if input.func() == image {
+        success("Content identified as image! Using `oasis-align-images` instead.")
+        oasis-align-images(vertical: vertical, swap: swap, margin: margin, item1, item2)
+        // return true
+      }
+    } else {return false}
+  }
+
+  [#check-if-image(item1)]
+
+  // if check-if-image(item1) {
+  //   oasis-align-images(vertical: vertical, swap: swap, margin: margin, item1, item2)
+  //   return
+  // }
+
+
 
   // use layout to measure measured-container
   layout(measured-container => {

--- a/oasis-align.typ
+++ b/oasis-align.typ
@@ -6,6 +6,7 @@
   vertical: false,
   swap: false,
   margin: 0pt,
+  override: false,
   range: (0, 1),
   int-frac: none, 
   int-dir: 1, 
@@ -51,11 +52,16 @@
   assert(type(ruler) == bool, message: "Ruler can be turned on or off only using boolean!")
   assert(type(debug) == bool, message: "Debug feed can be turned on or off only using boolean!")
 
-  let check-if-image(input) = type(input) == content and input.func() == image
 
-  if check-if-image(item1) and check-if-image(item2) {
+  if check-if-image(item1) and check-if-image(item2) and override == false {
     success("Content identified as image! Using `oasis-align-images` instead.")
     oasis-align-images(vertical: vertical, swap: swap, margin: margin, item1, item2)
+    return
+  }
+
+  if check-if-figure(item1) and check-if-figure(item2) and override == false {
+    success("Content identified as figure! Using `oasis-align-figures` instead.")
+    oasis-align-figures(vertical: vertical, swap: swap, margin: margin, item1, item2)
     return
   }
 

--- a/oasis-align.typ
+++ b/oasis-align.typ
@@ -1,7 +1,7 @@
 #let oasis-align(
   vertical: false,
   swap: false,
-  margin: 0in,
+  margin: 0pt,
   range: (0, 1),
   int-frac: none, 
   int-dir: 1, 
@@ -330,24 +330,34 @@
 #let oasis-align-images(
   vertical: false,
   swap: false, 
-  margin: 0in,
+  margin: 0pt,
   image1, 
   image2
 ) = context {
 
-  // let to-image(input) = {
-  //   if type(input) == str {
-  //     return image(path(input))
-  //   }
-  //   else if type(input) == path {
-  //     return image(input)
-  //   } else {
-  //     panic("Images should be passed as strings or paths!")
-  //   }
-  // }
+  let process-margin(m) = {
+    if type(m) == length {
+      m.to-absolute()
+    } else if type(m) == ratio {
+      m * container-side
+    } else if type(m) == relative {
+      m.ratio * container-side + m.length.to-absolute()
+    } else {
+      panic("Incorrect margin entry type: expected length, ratio, or relative, got " + str(type(m)))
+    }
+  }
 
-  // let image1 = to-image(image1)
-  // let image2 = to-image(image2)
+  let margins = {
+    if type(margin) == array {
+      if margin.len() != 2 {
+        panic("Margin array must contain exactly two entries!")
+      }
+      (process-margin(margin.at(0)), process-margin(margin.at(1)))
+    } else {
+      let calc-margin = process-margin(margin)
+      (calc-margin, calc-margin)
+    }
+  }
 
   // Find dimentional ratio between images
   let block1 = measure(image1)
@@ -357,15 +367,39 @@
 
   
   let display-output(dim1, dim2, vertical, swap) = {
-    if vertical {
-      if swap {grid(rows: (dim2, dim1), image2, image1)}
-      else    {grid(rows: (dim1, dim2), image1, image2)}
-    }
-    else {
-      if swap {grid(columns: (dim2, dim1), image2, image1)}
-      else    {grid(columns: (dim1, dim2), image1, image2)}
-    }
-  }
+        if vertical {
+          if swap {
+            pad(
+              top: margins.first(),
+              bottom: margins.last(),
+              grid(rows: (dim2, dim1), image2, image1)
+            )
+            }
+          else    {
+            pad(
+              top: margins.first(),
+              bottom: margins.last(),
+              grid(rows: (dim1, dim2), image1, image2)
+            )
+            }
+        }
+        else {
+          if swap {
+            pad(
+              left: margins.first(),
+              right: margins.last(),
+              grid(columns: (dim2, dim1), image2, image1)
+            )
+            }
+          else    {
+            pad(
+              left: margins.first(),
+              right: margins.last(),
+              grid(columns: (dim1, dim2), image1, image2)
+            )
+            }
+        }
+      }
 
   layout(measured-container => {
     // Measure size of continaner
@@ -373,6 +407,7 @@
     let side = if vertical {"height"} else {"width"}
     let container-side = measured-container.at(side)
     let grid-gutter = if vertical {grid.row-gutter} else {grid.column-gutter}
+    
     let gutter = {
       // In case grid.gutter is not defined, otherwise get first track sizing.
       let gutter = if grid-gutter == () {0% + 0pt} else {grid-gutter.first()}
@@ -383,7 +418,7 @@
       gutter
     }
     
-    let max-dim = container-side - gutter
+    let max-dim = container-side - gutter - margins.first() - margins.last()
     // Set widths of images
     let calcWidth1 = (max-dim)/(1/ratio + 1)
     let calcWidth2 = (max-dim)/(ratio + 1)

--- a/oasis-align.typ
+++ b/oasis-align.typ
@@ -1,6 +1,7 @@
 #let oasis-align(
-  swap: false,
   vertical: false,
+  swap: false,
+  margin: 0in,
   range: (0, 1),
   int-frac: none, 
   int-dir: 1, 
@@ -18,8 +19,9 @@
   let check-fraction(parameter) = (type(parameter) == float or parameter == 1  or parameter == 0) and parameter >= 0 and parameter <= 1
 
   // Check that inputs are valid
-  assert(type(swap) == bool, message: "Swap parameter must be true or false!")
   assert(type(vertical) == bool, message: "Vertical parameter condition must be true or false!")
+  assert(type(swap) == bool, message: "Swap parameter must be true or false!")
+  // assert(ty)
   assert(type(range) == array and range.len() == 2 and range.all(it => check-fraction(it)), message: "Range must be an array of two fractions!")
   assert(int-dir == -1 or int-dir == 1, message: "Initial direction parameter must be 1 or -1!")
   assert(int-frac == none or check-fraction(int-frac), message:"Initial fraction must be between 0 and 1!")
@@ -64,8 +66,16 @@
       gutter = container-side * gutter.ratio + gutter.length.to-absolute()
       gutter
     }
+    let margins = {
+      if type(margin) == length {
+        (margin, margin)
+      } else if type(margin) == array {
+        margin
+      }
+    }
 
-    let max-dim = container-side - gutter
+
+    let max-dim = container-side - gutter - margins.first() - margins.last()
     let dim-1a    // Bounding dimension of item1
     let dim-2a    // Bounding dimension of item2
     let dim-1b   // Measured dimension of item1 using dim-1a
@@ -107,12 +117,36 @@
 
     let display-output(dim1, dim2, vertical, swap) = {
       if vertical {
-        if swap {grid(rows: (dim2, dim1), item2, item1)}
-        else    {grid(rows: (dim1, dim2), item1, item2)}
+        if swap {
+          pad(
+            top: margins.first(),
+            bottom: margins.last(),
+            grid(rows: (dim2, dim1), item2, item1)
+          )
+          }
+        else    {
+          pad(
+            top: margins.first(),
+            bottom: margins.last(),
+            grid(rows: (dim1, dim2), item1, item2)
+          )
+          }
       }
       else {
-        if swap {grid(columns: (dim2, dim1), item2, item1)}
-        else    {grid(columns: (dim1, dim2), item1, item2)}
+        if swap {
+          pad(
+            left: margins.first(),
+            right: margins.last(),
+            grid(columns: (dim2, dim1), item2, item1)
+          )
+          }
+        else    {
+          pad(
+            left: margins.first(),
+            right: margins.last(),
+            grid(columns: (dim1, dim2), item1, item2)
+          )
+          }
       }
     }
 
@@ -149,7 +183,7 @@
       )
       
       place(
-        horizon + center, 
+        horizon + center,
         stack(
           dir: stack-direction, 
           spacing: 10%,
@@ -265,6 +299,20 @@
   image1, 
   image2
 ) = context {
+
+  // let to-image(input) = {
+  //   if type(input) == str {
+  //     return image(path(input))
+  //   }
+  //   else if type(input) == path {
+  //     return image(input)
+  //   } else {
+  //     panic("Images should be passed as strings or paths!")
+  //   }
+  // }
+
+  // let image1 = to-image(image1)
+  // let image2 = to-image(image2)
 
   // Find dimentional ratio between images
   let block1 = measure(image1)

--- a/oasis-align.typ
+++ b/oasis-align.typ
@@ -54,8 +54,7 @@
   layout(measured-container => {
 
     // Relevant container side, depending on `vertical`.
-    let side = if vertical {"height"} else {"width"}
-    let container-side = measured-container.at(side)
+    let container-side = if vertical { measured-container.height } else { measured-container.width }
     let grid-gutter = if vertical {grid.row-gutter} else {grid.column-gutter}
 
     let gutter = {
@@ -339,8 +338,7 @@
   layout(measured-container => {
     // Measure size of continaner
     // let container = size.width
-    let side = if vertical {"height"} else {"width"}
-    let container-side = measured-container.at(side)
+    let container-side = if vertical { measured-container.height } else { measured-container.width }
     let grid-gutter = if vertical {grid.row-gutter} else {grid.column-gutter}
     
     let gutter = {

--- a/oasis-align.typ
+++ b/oasis-align.typ
@@ -68,20 +68,27 @@
       gutter
     }
 
-    let margins = {
-      if type(margin) == length {
-        (margin.to-absolute(), margin.to-absolute())
-      } else if type(margin) == ratio {
-        let calc-margin = margin * container-side
-        (calc-margin, calc-margin)
-      } else if type(margin) == relative {
-        let calc-margin = margin.ratio * container-side + margin.length.to-absolute()
-        (calc-margin, calc-margin)
-      } else if type(margin) == array {
-        if margin.flatten().len() != 2 {panic("Margin array should only have two entries!")}
-        margin
+    let process-margin(m) = {
+      if type(m) == length {
+        m.to-absolute()
+      } else if type(m) == ratio {
+        m * container-side
+      } else if type(m) == relative {
+        m.ratio * container-side + m.length.to-absolute()
       } else {
-        panic("Incorrect margin parameter type. Please use a length, ratio, or relative!")
+        panic("Incorrect margin entry type: expected length, ratio, or relative, got " + str(type(m)))
+      }
+    }
+
+    let margins = {
+      if type(margin) == array {
+        if margin.len() != 2 {
+          panic("Margin array must contain exactly two entries!")
+        }
+        (process-margin(margin.at(0)), process-margin(margin.at(1)))
+      } else {
+        let calc-margin = process-margin(margin)
+        (calc-margin, calc-margin)
       }
     }
 

--- a/oasis-align.typ
+++ b/oasis-align.typ
@@ -115,42 +115,12 @@
       return (out1, out2, diff)
     }
 
-    let display-output(dim1, dim2, vertical, swap) = {
-      if vertical {
-        if swap {
-          pad(
-            top: margins.first(),
-            bottom: margins.last(),
-            grid(rows: (dim2, dim1), item2, item1)
-          )
-          }
-        else    {
-          pad(
-            top: margins.first(),
-            bottom: margins.last(),
-            grid(rows: (dim1, dim2), item1, item2)
-          )
-          }
-      }
-      else {
-        if swap {
-          pad(
-            left: margins.first(),
-            right: margins.last(),
-            grid(columns: (dim2, dim1), item2, item1)
-          )
-          }
-        else    {
-          pad(
-            left: margins.first(),
-            right: margins.last(),
-            grid(columns: (dim1, dim2), item1, item2)
-          )
-          }
-      }
-    }
-
-    let show-ruler(ruler-dim, ratio: .7, color: red.transparentize(20%), vertical) = {
+    let show-ruler(
+      ruler-dim, 
+      vertical, 
+      ratio: .7, 
+      color: red.transparentize(20%)
+    ) = {
       if ruler == false {return}
       
       let stack-direction
@@ -199,6 +169,53 @@
         horizon + center,
         line(length: 100%, angle: calc.abs(line-angle - 90deg), stroke: (thickness: 3pt, paint: color, cap: "round"))
       )
+    }
+
+    let display-output(dim1, dim2, vertical, swap, ruler-dim) = {
+      if vertical {
+        if swap {
+          pad(
+            top: margins.first(),
+            bottom: margins.last(),
+            {
+              grid(rows: (dim2, dim1), item2, item1)
+              show-ruler(ruler-dim, vertical)
+            }
+          )
+          }
+        else    {
+          pad(
+            top: margins.first(),
+            bottom: margins.last(),
+            {
+              grid(rows: (dim1, dim2), item1, item2)
+              show-ruler(ruler-dim, vertical)
+            }
+          )
+          }
+      }
+      else {
+        if swap {
+          pad(
+            left: margins.first(),
+            right: margins.last(),
+            {
+              grid(columns: (dim2, dim1), item2, item1)
+              show-ruler(ruler-dim, vertical)
+            }
+          )
+          }
+        else    {
+          pad(
+            left: margins.first(),
+            right: margins.last(),
+            {
+              grid(columns: (dim1, dim2), item1, item2)
+              show-ruler(ruler-dim, vertical)
+            }
+          )
+          }
+      }
     }
 
     // Loop max to prevent infinite loop
@@ -256,8 +273,7 @@
       // Check if within tolerance. If so, display
       if diff < tolerance or n >= max-iterations or dir-change >= 2 or override {
         success([Displaying output...])
-        display-output(dim-1a, dim-2a, vertical, swap)
-        show-ruler(dim-1b, vertical)
+        display-output(dim-1a, dim-2a, vertical, swap, dim-1b)
         break
       }
       // Use bisection method by setting new bounds

--- a/oasis-align.typ
+++ b/oasis-align.typ
@@ -335,72 +335,7 @@
   image2
 ) = context {
 
-  let process-margin(m) = {
-    if type(m) == length {
-      m.to-absolute()
-    } else if type(m) == ratio {
-      m * container-side
-    } else if type(m) == relative {
-      m.ratio * container-side + m.length.to-absolute()
-    } else {
-      panic("Incorrect margin entry type: expected length, ratio, or relative, got " + str(type(m)))
-    }
-  }
-
-  let margins = {
-    if type(margin) == array {
-      if margin.len() != 2 {
-        panic("Margin array must contain exactly two entries!")
-      }
-      (process-margin(margin.at(0)), process-margin(margin.at(1)))
-    } else {
-      let calc-margin = process-margin(margin)
-      (calc-margin, calc-margin)
-    }
-  }
-
-  // Find dimentional ratio between images
-  let block1 = measure(image1)
-  let block2 = measure(image2)
-  let ratio = if vertical {(block1.height/block1.width)*block2.width/block2.height}
-              else {(block1.width/block1.height)*block2.height/block2.width}
-
   
-  let display-output(dim1, dim2, vertical, swap) = {
-        if vertical {
-          if swap {
-            pad(
-              top: margins.first(),
-              bottom: margins.last(),
-              grid(rows: (dim2, dim1), image2, image1)
-            )
-            }
-          else    {
-            pad(
-              top: margins.first(),
-              bottom: margins.last(),
-              grid(rows: (dim1, dim2), image1, image2)
-            )
-            }
-        }
-        else {
-          if swap {
-            pad(
-              left: margins.first(),
-              right: margins.last(),
-              grid(columns: (dim2, dim1), image2, image1)
-            )
-            }
-          else    {
-            pad(
-              left: margins.first(),
-              right: margins.last(),
-              grid(columns: (dim1, dim2), image1, image2)
-            )
-            }
-        }
-      }
-
   layout(measured-container => {
     // Measure size of continaner
     // let container = size.width
@@ -417,12 +352,77 @@
       gutter = container-side * gutter.ratio + gutter.length.to-absolute()
       gutter
     }
+
+    let process-margin(m) = {
+      if type(m) == length {
+        m.to-absolute()
+      } else if type(m) == ratio {
+        m * container-side
+      } else if type(m) == relative {
+        m.ratio * container-side + m.length.to-absolute()
+      } else {
+        panic("Incorrect margin entry type: expected length, ratio, or relative, got " + str(type(m)))
+      }
+    }
+
+    let margins = {
+      if type(margin) == array {
+        if margin.len() != 2 {
+          panic("Margin array must contain exactly two entries!")
+        }
+        (process-margin(margin.at(0)), process-margin(margin.at(1)))
+      } else {
+        let calc-margin = process-margin(margin)
+        (calc-margin, calc-margin)
+      }
+    }
+
+    
+    let display-output(dim1, dim2, vertical, swap) = {
+      if vertical {
+        if swap {
+          pad(
+            top: margins.first(),
+            bottom: margins.last(),
+            grid(rows: (dim2, dim1), image2, image1)
+          )
+        }
+        else {
+          pad(
+            top: margins.first(),
+            bottom: margins.last(),
+            grid(rows: (dim1, dim2), image1, image2)
+          )
+        }
+      }
+      else {
+        if swap {
+          pad(
+            left: margins.first(),
+            right: margins.last(),
+            grid(columns: (dim2, dim1), image2, image1)
+          )
+        }
+        else {
+          pad(
+            left: margins.first(),
+            right: margins.last(),
+            grid(columns: (dim1, dim2), image1, image2)
+          )
+        }
+      }
+    }
+
+      // Find dimentional ratio between images
+    let block1 = measure(image1)
+    let block2 = measure(image2)
+    let ratio = if vertical {(block1.height/block1.width)*block2.width/block2.height}
+                else {(block1.width/block1.height)*block2.height/block2.width}
     
     let max-dim = container-side - gutter - margins.first() - margins.last()
     // Set widths of images
     let calcWidth1 = (max-dim)/(1/ratio + 1)
     let calcWidth2 = (max-dim)/(ratio + 1)
-
 
     // Display images in grid
     display-output(calcWidth1, calcWidth2, vertical, swap)

--- a/oasis-align.typ
+++ b/oasis-align.typ
@@ -50,35 +50,17 @@
   assert(type(max-iterations) == int, message: "The maximum number of iterations must be an integer! Lowering the number may find a solution quicker, but it may no be within tolerance.")
   assert(type(ruler) == bool, message: "Ruler can be turned on or off only using boolean!")
   assert(type(debug) == bool, message: "Debug feed can be turned on or off only using boolean!")
-  
-  let check-if-image(input) = {
-    if type(input) == content {
-        success("Content identified as image! Using `oasis-align-images` instead.")
-      if input.func() == image {
-        success("Content identified as image! Using `oasis-align-images` instead.")
-        oasis-align-images(vertical: vertical, swap: swap, margin: margin, item1, item2)
-        // return true
-      }
-    } else {return false}
+
+  let check-if-image(input) = type(input) == content and input.func() == image
+
+  if check-if-image(item1) and check-if-image(item2) {
+    success("Content identified as image! Using `oasis-align-images` instead.")
+    oasis-align-images(vertical: vertical, swap: swap, margin: margin, item1, item2)
+    return
   }
-
-  [#check-if-image(item1)]
-
-  // if check-if-image(item1) {
-  //   oasis-align-images(vertical: vertical, swap: swap, margin: margin, item1, item2)
-  //   return
-  // }
-
-
 
   // use layout to measure measured-container
   layout(measured-container => {
-
-    // let content-type1 = check-content-type(item1)
-    // let content-type2 = check-content-type(item2)
-    // if content-type1 == "image" and content-type2 == "image" {
-    //   oasis-align-images(vertical: vertical, swap: swap, margin: margin, item1, image2)
-    // }
 
     // Relevant container side, depending on `vertical`.
     let container-side = if vertical { measured-container.height } else { measured-container.width }

--- a/oasis-align.typ
+++ b/oasis-align.typ
@@ -1,4 +1,6 @@
 #import "utils.typ": *
+// #import "oasis-align-images.typ": oasis-align-images
+// #import "oasis-align-figures.typ": oasis-align-figures
 
 #let oasis-align(
   vertical: false,
@@ -18,6 +20,20 @@
   item2, 
 ) = context {
 
+  // Debug functions
+  let heads-up(message) = if debug {block(text(blue, weight: "bold", message))}
+  let warning(message) = if debug {block(text(red.darken(15%), weight: "bold", message))}
+  let success(message) = if debug {block(text(green.darken(30%), weight: "bold", message))}
+  let system-info(message) = if debug {
+    show raw.where(block: false): box.with(
+        fill: luma(240),
+        inset: (x: 3pt, y: 0pt),
+        outset: (y: 3pt),
+        radius: 2pt,
+      )  
+      message
+  }
+
   let check-fraction(parameter) = (type(parameter) == float or parameter == 1  or parameter == 0) and parameter >= 0 and parameter <= 1
 
   // Check that inputs are valid
@@ -36,23 +52,14 @@
   assert(type(debug) == bool, message: "Debug feed can be turned on or off only using boolean!")
   
 
-  // Debug functions
-  let heads-up(message) = if debug {block(text(blue, weight: "bold", message))}
-  let warning(message) = if debug {block(text(red.darken(15%), weight: "bold", message))}
-  let success(message) = if debug {block(text(green.darken(30%), weight: "bold", message))}
-  let system-info(message) = if debug {
-    show raw.where(block: false): box.with(
-        fill: luma(240),
-        inset: (x: 3pt, y: 0pt),
-        outset: (y: 3pt),
-        radius: 2pt,
-      )  
-      message
-  }
-  
-  
   // use layout to measure measured-container
   layout(measured-container => {
+
+    // let content-type1 = check-content-type(item1)
+    // let content-type2 = check-content-type(item2)
+    // if content-type1 == "image" and content-type2 == "image" {
+    //   oasis-align-images(vertical: vertical, swap: swap, margin: margin, item1, image2)
+    // }
 
     // Relevant container side, depending on `vertical`.
     let container-side = if vertical { measured-container.height } else { measured-container.width }
@@ -77,12 +84,7 @@
     let n = 0
     let dir-change = 0
     let override = if force-frac != none {true} else {false}
-
-    let split-layout(max-distance, fraction) = {
-      let dim1 = fraction * max-distance
-      let dim2 = (1 - fraction) * max-distance
-      return (dim1, dim2)
-    }
+  
 
     // Loop max to prevent infinite loop
     while n < max-iterations {

--- a/oasis-align.typ
+++ b/oasis-align.typ
@@ -5,8 +5,9 @@
 #let oasis-align(
   vertical: false,
   swap: false,
-  margin: 0pt,
+  padding: 0pt,
   override: false,
+  ruler: false,
   range: (0, 1),
   int-frac: none, 
   int-dir: 1, 
@@ -15,7 +16,6 @@
   frac-limit: 1e-5,  
   tolerance: 0.01pt,
   max-iterations: 30, 
-  ruler: false,
   debug: false,
   item1, 
   item2, 
@@ -55,13 +55,13 @@
 
   if check-if-image(item1) and check-if-image(item2) and override == false {
     success("Content identified as image! Using `oasis-align-images` instead.")
-    oasis-align-images(vertical: vertical, swap: swap, margin: margin, item1, item2)
+    oasis-align-images(vertical: vertical, swap: swap, padding: padding, item1, item2)
     return
   }
 
   if check-if-figure(item1) and check-if-figure(item2) and override == false {
     success("Content identified as figure! Using `oasis-align-figures` instead.")
-    oasis-align-figures(vertical: vertical, swap: swap, margin: margin, item1, item2)
+    oasis-align-figures(vertical: vertical, swap: swap, padding: padding, item1, item2)
     return
   }
 
@@ -70,10 +70,10 @@
 
     // Relevant container side, depending on `vertical`.
     let container-side = if vertical { measured-container.height } else { measured-container.width }
-    let margins = process-margin(margin, container-side)
+    let paddings = process-padding(padding, container-side)
     let gutter = process-gutter(vertical, container-side)
 
-    let max-dim = container-side - gutter - margins.first() - margins.last()
+    let max-dim = container-side - gutter - paddings.first() - paddings.last()
     let dim-1a    // Bounding dimension of item1
     let dim-2a    // Bounding dimension of item2
     let dim-1b   // Measured dimension of item1 using dim-1a
@@ -148,7 +148,7 @@
       // Check if within tolerance. If so, display
       if diff < tolerance or n >= max-iterations or dir-change >= 2 or override {
         success([Displaying output...])
-        display-output(item1, item2, dim-1a, dim-2a, vertical, swap, margins, ruler, dim-1b)
+        display-output(item1, item2, dim-1a, dim-2a, vertical, swap, paddings, ruler, dim-1b)
         break
       }
       // Use bisection method by setting new bounds

--- a/typst.toml
+++ b/typst.toml
@@ -1,7 +1,7 @@
 [package]
 name = "oasis-align"
-version = "0.3.3"
-entrypoint = "oasis-align.typ"
+version = "0.4.0"
+entrypoint = "lib.typ"
 authors = ["@jdpieck"]
 license = "MIT"
 description = "Cleanly place content side by side with equal heights using automatic content sizing."

--- a/utils.typ
+++ b/utils.typ
@@ -1,3 +1,13 @@
+// #let check-content-type(input) = {
+//   // assert(type(input) == content, message: "The input arguments must be a type of content!")
+
+//   if input.func() == image {"image"}
+//   else if input.func() == figure {
+//     if input.body.func() == image {"image-figure"}
+//   } else {"other"}
+}
+
+
 #let split-layout(max-distance, fraction) = {
       let dim1 = fraction * max-distance
       let dim2 = (1 - fraction) * max-distance
@@ -59,6 +69,13 @@
     gutter 
 }
 
+#let find-image-ratio(image1, image2, vertical) = {
+  let block1 = measure(image1)
+  let block2 = measure(image2)
+
+  if vertical {(block1.height/block1.width)*block2.width/block2.height}
+  else {(block1.width/block1.height)*block2.height/block2.width}
+}
 
 #let show-ruler(
   ruler-state,
@@ -162,4 +179,18 @@
       )
       }
   }
+}
+
+  // Debug functions
+#let heads-up(message) = if debug {block(text(blue, weight: "bold", message))}
+#let warning(message) = if debug {block(text(red.darken(15%), weight: "bold", message))}
+#let success(message) = if debug {block(text(green.darken(30%), weight: "bold", message))}
+#let system-info(message) = if debug {
+  show raw.where(block: false): box.with(
+      fill: luma(240),
+      inset: (x: 3pt, y: 0pt),
+      outset: (y: 3pt),
+      radius: 2pt,
+    )  
+    message
 }

--- a/utils.typ
+++ b/utils.typ
@@ -1,0 +1,165 @@
+#let split-layout(max-distance, fraction) = {
+      let dim1 = fraction * max-distance
+      let dim2 = (1 - fraction) * max-distance
+      return (dim1, dim2)
+    }
+
+#let measure-difference(item1, item2, dim1, dim2, vertical) = {
+  let (out1, out2) =  if vertical {
+    (
+      measure(block(height: dim1, item1)).width.to-absolute(),
+      measure(block(height: dim2, item2)).width.to-absolute()
+    )
+  } else {
+    (
+      measure(block(width: dim1, item1)).height.to-absolute(),
+      measure(block(width: dim2, item2)).height.to-absolute()
+    )
+  }
+
+  let diff = calc.abs(out1 - out2)
+
+  (out1, out2, diff)
+}
+
+#let process-margin(input, container-dim) = {
+
+  let check-margin-type(m) = {
+    if type(m) == length {
+      m.to-absolute()
+    } else if type(m) == ratio {
+      m * container-dim
+    } else if type(m) == relative {
+      m.ratio * container-dim + m.length.to-absolute()
+    } else {
+      panic("Incorrect margin entry type: expected length, ratio, or relative, got " + str(type(m)))
+    }
+  }
+
+  if type(input) == array {
+    if input.len() != 2 {
+      panic("Margin array must contain exactly two entries!")
+    }
+    (check-margin-type(input.at(0)), check-margin-type(input.at(1)))
+  } else {
+    let calc-margin = check-margin-type(input)
+    (calc-margin, calc-margin)
+  }
+}
+
+#let process-gutter(vertical, container-dim) = {
+    let grid-gutter = if vertical {grid.row-gutter} else {grid.column-gutter}
+    
+    // In case grid.gutter is not defined, otherwise get first track sizing.
+    let gutter = if grid-gutter == () {0% + 0pt} else {grid-gutter.first()}
+    // In case grid.gutter is `int`, `auto`, `fraction`, ignore the value.
+    if gutter == auto or type(gutter) == fraction { gutter = 0% + 0pt }
+    // Convert `relative` length to absolute `length`.
+    gutter = container-dim * gutter.ratio + gutter.length.to-absolute()
+    gutter 
+}
+
+
+#let show-ruler(
+  ruler-state,
+  ruler-dim, 
+  vertical, 
+  ratio: .7, 
+  color: red.transparentize(20%)
+) = {
+  if ruler-state == false {return}
+  
+  let stack-direction
+  let line-angle
+
+  if vertical {
+    stack-direction = ttb
+    line-angle = 0deg
+  } else {
+    stack-direction = ltr
+    line-angle = 90deg
+  }
+
+  let major-line  = line(
+    length: ruler-dim * ratio, 
+    angle: line-angle, 
+    stroke: (thickness: .4em, paint: color, cap: "round")
+  )
+
+  let median-line = line(
+    length: ruler-dim * ratio * .8, 
+    angle: line-angle, 
+    stroke: (thickness: .3em, paint: color, cap: "round")
+  )
+
+  let minor-line  = line(
+    length: ruler-dim * ratio * .5, 
+    angle: line-angle, 
+    stroke: (thickness: .3em, paint: color, cap: "round")
+  )
+  
+  place(
+    horizon + center,
+    stack(
+      dir: stack-direction, 
+      spacing: 10%,
+      major-line, 
+      minor-line, minor-line, minor-line, minor-line,
+      major-line,
+      minor-line, minor-line, minor-line, minor-line,
+      major-line,
+    )
+  )
+  
+  place(
+    horizon + center,
+    line(length: 100%, angle: calc.abs(line-angle - 90deg), stroke: (thickness: 3pt, paint: color, cap: "round"))
+  )
+}
+
+#let display-output(item1, item2, dim1, dim2, vertical, swap, margins, ruler-state, ruler-dim) = {
+  if vertical {
+    if swap {
+      pad(
+        top: margins.first(),
+        bottom: margins.last(),
+        {
+          grid(rows: (dim2, dim1), item2, item1)
+          show-ruler(ruler-state, ruler-dim, vertical)
+        }
+      )
+      }
+    else    {
+      pad(
+        top: margins.first(),
+        bottom: margins.last(),
+        {
+          grid(rows: (dim1, dim2), item1, item2)
+          show-ruler(ruler-state, ruler-dim, vertical)
+        }
+      )
+      }
+  }
+  else {
+    if swap {
+      pad(
+        left: margins.first(),
+        right: margins.last(),
+        {
+          grid(columns: (dim2, dim1), item2, item1)
+          show-ruler(ruler-state, ruler-dim, vertical)
+        }
+      )
+      }
+    else    {
+      pad(
+        left: margins.first(),
+        right: margins.last(),
+        {
+          grid(columns: (dim1, dim2), item1, item2)
+          show-ruler(ruler-state, ruler-dim, vertical)
+        }
+      )
+      }
+  }
+}

--- a/utils.typ
+++ b/utils.typ
@@ -1,12 +1,7 @@
-// #let check-content-type(input) = {
-//   // assert(type(input) == content, message: "The input arguments must be a type of content!")
+#let check-if-image(input) = type(input) == content and input.func() == image
 
-//   if input.func() == image {"image"}
-//   else if input.func() == figure {
-//     if input.body.func() == image {"image-figure"}
-//   } else {"other"}
-}
 
+#let check-if-figure(input) = type(input) == content and ((input.func() == figure and input.body.func() == image) or (repr(input.func()) == "sequence" and input.children.at(0).func() == figure and input.children.at(0).body.func() == image))
 
 #let split-layout(max-distance, fraction) = {
       let dim1 = fraction * max-distance

--- a/utils.typ
+++ b/utils.typ
@@ -27,9 +27,9 @@
   (out1, out2, diff)
 }
 
-#let process-margin(input, container-dim) = {
+#let process-padding(input, container-dim) = {
 
-  let check-margin-type(m) = {
+  let check-padding-type(m) = {
     if type(m) == length {
       m.to-absolute()
     } else if type(m) == ratio {
@@ -37,18 +37,18 @@
     } else if type(m) == relative {
       m.ratio * container-dim + m.length.to-absolute()
     } else {
-      panic("Incorrect margin entry type: expected length, ratio, or relative, got " + str(type(m)))
+      panic("Incorrect padding entry type: expected length, ratio, or relative, got " + str(type(m)))
     }
   }
 
   if type(input) == array {
     if input.len() != 2 {
-      panic("Margin array must contain exactly two entries!")
+      panic("Padding array must contain exactly two entries!")
     }
-    (check-margin-type(input.at(0)), check-margin-type(input.at(1)))
+    (check-padding-type(input.at(0)), check-padding-type(input.at(1)))
   } else {
-    let calc-margin = check-margin-type(input)
-    (calc-margin, calc-margin)
+    let calc-padding = check-padding-type(input)
+    (calc-padding, calc-padding)
   }
 }
 
@@ -129,12 +129,12 @@
   )
 }
 
-#let display-output(item1, item2, dim1, dim2, vertical, swap, margins, ruler-state, ruler-dim) = {
+#let display-output(item1, item2, dim1, dim2, vertical, swap, paddings, ruler-state, ruler-dim) = {
   if vertical {
     if swap {
       pad(
-        top: margins.first(),
-        bottom: margins.last(),
+        top: paddings.first(),
+        bottom: paddings.last(),
         {
           grid(rows: (dim2, dim1), item2, item1)
           show-ruler(ruler-state, ruler-dim, vertical)
@@ -143,8 +143,8 @@
       }
     else    {
       pad(
-        top: margins.first(),
-        bottom: margins.last(),
+        top: paddings.first(),
+        bottom: paddings.last(),
         {
           grid(rows: (dim1, dim2), item1, item2)
           show-ruler(ruler-state, ruler-dim, vertical)
@@ -155,8 +155,8 @@
   else {
     if swap {
       pad(
-        left: margins.first(),
-        right: margins.last(),
+        left: paddings.first(),
+        right: paddings.last(),
         {
           grid(columns: (dim2, dim1), item2, item1)
           show-ruler(ruler-state, ruler-dim, vertical)
@@ -165,8 +165,8 @@
       }
     else    {
       pad(
-        left: margins.first(),
-        right: margins.last(),
+        left: paddings.first(),
+        right: paddings.last(),
         {
           grid(columns: (dim1, dim2), item1, item2)
           show-ruler(ruler-state, ruler-dim, vertical)


### PR DESCRIPTION
- added `padding` to all functions
    - helps when you don't want the content spanning the full page
- added `figure` variant of `oasis-align()`
    - for when you want to align the images but not the caption text
- added content ID system to automatically switch from `oasis-align()` to `oasis-align-images()` and `oasis-align-figures()` logic based on input content type
    - increased performance of image-image and figure-figure alignment 
    - added `override` parameter to override this behavior
- major refactoring of codebases
    - added help functions under `utils.typ`
    - separated `image` and `figure` variants of `oasis-align()` into separate files